### PR TITLE
Fix: Github Release Tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,10 @@ collect_artifacts:
 	mkdir -p artifacts
 	cp -rv $(DIST_DIR)/* artifacts
 
+# We are making the Github release tool static to v0.16.2, since in v0.17.0 and above, we are required to use
+# Golang version 1.23. Thus we keep it with a compatible version for us, until we bump Golang to that version.
 release:
-	go install github.com/tcnksm/ghr@latest
+	go install github.com/tcnksm/ghr@v0.16.2
 	ghr -prerelease -n $$RELEASE_VERSION $$RELEASE_VERSION artifacts/
 
 clean:


### PR DESCRIPTION
Making the pipeline github release tool version static until we bump Vcert to Golang v1.23, as currently, our pipeline running always latest, throw us error:
```
[2024-11-07T16:53:09.909Z] echo '```' >> release.txt
[2024-11-07T16:53:09.909Z] go install github.com/tcnksm/ghr@latest
[2024-11-07T16:53:22.070Z] go: downloading github.com/tcnksm/ghr v0.17.0
[2024-11-07T16:53:22.070Z] go: github.com/tcnksm/ghr@latest: github.com/tcnksm/ghr@v0.17.0 requires go >= 1.23 (running go 1.21.8; GOTOOLCHAIN=local)
[2024-11-07T16:53:22.070Z] make: *** [Makefile:123: release] Error 1
```
Looking at the Github project [here](https://github.com/tcnksm/ghr/releases), we can see that from **0.16.2** to **0.17.0** version, they bumped golang from version **1.19** to **1.23**. Hence, we are making our pipeline static to the version **0.16.2**, until we bump Go version up to **1.23**

References:
- https://github.com/tcnksm/ghr/compare/v0.16.2...v0.17.0
- https://github.com/tcnksm/ghr/commit/d27ed8d42235b4a75780ab7863e41f1358418da4