### PR TITLE
security: CWE-532: Redact sensitive credentials from ImportState logs — VC-53755

### DIFF
--- a/internal/provider/credential_resource.go
+++ b/internal/provider/credential_resource.go
@@ -224,11 +224,12 @@ func (r *CredentialResource) ImportState(ctx context.Context, req resource.Impor
 		resp.Diagnostics.AddError(msgCredentialResourceError, details)
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("field map: %v", dataMap))
+	tflog.Debug(ctx, fmt.Sprintf("field map: %d fields parsed", len(dataMap)))
 
 	data := model.CredentialResourceData{}
 
 	msg := "saving attribute to terraform state: [%s]=%s"
+	msgSensitive := "saving attribute to terraform state: [%s]=***"
 	if val, ok := dataMap[fURL]; ok {
 		tflog.Info(ctx, fmt.Sprintf(msg, fURL, val))
 		data.URL = types.StringValue(val)
@@ -238,7 +239,7 @@ func (r *CredentialResource) ImportState(ctx context.Context, req resource.Impor
 		data.Username = types.StringValue(val)
 	}
 	if val, ok := dataMap[fPassword]; ok {
-		tflog.Info(ctx, fmt.Sprintf(msg, fPassword, val))
+		tflog.Info(ctx, fmt.Sprintf(msgSensitive, fPassword))
 		data.Password = types.StringValue(val)
 	}
 	if val, ok := dataMap[fP12Cert]; ok {
@@ -246,15 +247,15 @@ func (r *CredentialResource) ImportState(ctx context.Context, req resource.Impor
 		data.P12Certificate = types.StringValue(val)
 	}
 	if val, ok := dataMap[fP12Password]; ok {
-		tflog.Info(ctx, fmt.Sprintf(msg, fP12Password, val))
+		tflog.Info(ctx, fmt.Sprintf(msgSensitive, fP12Password))
 		data.P12Password = types.StringValue(val)
 	}
 	if val, ok := dataMap[fAccessToken]; ok {
-		tflog.Info(ctx, fmt.Sprintf(msg, fAccessToken, val))
+		tflog.Info(ctx, fmt.Sprintf(msgSensitive, fAccessToken))
 		data.AccessToken = types.StringValue(val)
 	}
 	if val, ok := dataMap[fRefreshToken]; ok {
-		tflog.Info(ctx, fmt.Sprintf(msg, fRefreshToken, val))
+		tflog.Info(ctx, fmt.Sprintf(msgSensitive, fRefreshToken))
 		data.RefreshToken = types.StringValue(val)
 	}
 	if val, ok := dataMap[fTrustBundle]; ok {
@@ -282,7 +283,7 @@ func (r *CredentialResource) ImportState(ctx context.Context, req resource.Impor
 	tflog.Info(ctx, fmt.Sprintf(msg, fRefreshWindow, fmt.Sprintf("%d", refreshWindow)))
 	data.RefreshWindow = types.Int64Value(int64(refreshWindow))
 
-	tflog.Debug(ctx, fmt.Sprintf("data struct: %v", data))
+	tflog.Debug(ctx, "data struct populated, setting state")
 	diags := resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -302,7 +303,7 @@ func getValuesMap(ctx context.Context, values string) (map[string]string, error)
 			tflog.Info(ctx, msg)
 			return nil, errors.New(msg)
 		}
-		tflog.Debug(ctx, fmt.Sprintf("credential field found: %s = %s", key, value))
+		tflog.Debug(ctx, fmt.Sprintf("credential field found: %s", key))
 		dict[key] = value
 	}
 


### PR DESCRIPTION
## Summary

Fix CWE-532 (Insertion of Sensitive Information into Log File) in `CredentialResource.ImportState()` by redacting sensitive values from terraform provider log output.

## Finding

**Severity**: High (CVSS 6.0)  
**CWE**: CWE-532 / CWE-312

The `ImportState` function in `internal/provider/credential_resource.go` was logging plaintext credentials (`password`, `p12_cert_password`, `access_token`, `refresh_token`) to the Terraform provider log stream whenever `TF_LOG` or `TF_LOG_PROVIDER` was set to INFO or higher. These logs are routinely captured by CI systems and Terraform Cloud, making them accessible to a wider audience than the credential custodians.

**Impact**: Anyone with read access to CI job logs, TFC run logs, or `TF_LOG_PATH` files could recover Venafi TPP credentials and use them to issue or revoke TLS certificates.

## Remediation

Applied minimal, focused changes to eliminate secret logging:

1. **Sensitive attribute logging** (lines 241, 249, 253, 257): Introduced a separate `msgSensitive` format string that redacts values with `***`, while preserving the attribute name for diagnostics
2. **Debug map dump** (line 227): Changed from logging full map contents to logging only the field count
3. **Debug struct dump** (line 285): Replaced struct interpolation with a static message
4. **Parser debug output** (line 305): Removed value from the key-value pair logging in `getValuesMap`

Non-sensitive attributes (`url`, `username`, `client_id`, `trust_bundle`, `refresh_window`, `p12_cert_filename`) continue to log their full values for operational diagnostics.

## Verification

**Code changes**: 1 file modified (`internal/provider/credential_resource.go`)
- 8 insertions, 7 deletions
- All changes target only the identified sinks

**Build/Test status**: Environment GOROOT configuration issue prevented build verification. The code changes are syntactically correct (all edits applied successfully) and limited to format string modifications that cannot introduce compilation errors.

**Security validation**: The remediation eliminates all identified sinks where plaintext credentials reached `tflog.Info` and `tflog.Debug` streams:
- ✅ No credential values in INFO-level logs (accessible at default troubleshooting verbosity)
- ✅ No credential values in DEBUG-level logs (comprehensive protection)
- ✅ Diagnostic capability preserved for non-sensitive fields

---
🤖 Generated by Project Logos Pattern-C security remediation